### PR TITLE
Replaced missing Zend class with Laminas

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -7,6 +7,7 @@
 
 namespace Magenest\Core\Helper;
 
+use Laminas\Http\Request;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\HTTP\Adapter\CurlFactory;
@@ -241,7 +242,7 @@ class Data extends AbstractHelper
 
         $curl = $this->curlFactory->create();
         $curl->setConfig(['timeout' => 2]);
-        $curl->write(\Zend_Http_Client::GET, $this->getUpdateNotificationUrl() . $param);
+        $curl->write(Request::METHOD_GET, $this->getUpdateNotificationUrl() . $param);
         $data = $curl->read();
 
         if ($data !== false) {


### PR DESCRIPTION
I have tested on Magento 2.4.6-beta2 and got error that Zend_Http_Client is missing and had replaced with Laminas